### PR TITLE
Add streaming mode and ctrl options

### DIFF
--- a/SmRtAPI/SmRtAPI/Messages/StartRecognitionMessage.cs
+++ b/SmRtAPI/SmRtAPI/Messages/StartRecognitionMessage.cs
@@ -1,7 +1,7 @@
-﻿using Speechmatics.Realtime.Client.Enumerations;
+﻿using Newtonsoft.Json;
+using Speechmatics.Realtime.Client.Enumerations;
 using Speechmatics.Realtime.Client.Messages;
 using System.Collections.Generic;
-using System.Text.Json;
 
 namespace Speechmatics.Realtime.Client.Messages
 {
@@ -12,7 +12,7 @@ namespace Speechmatics.Realtime.Client.Messages
             audio_format = audioFormatSubMessage;
             if (smConfig.Ctrl != null)
             {
-                transcription_config["ctrl"] = JsonSerializer.Deserialize<Dictionary<string, object>>(smConfig.Ctrl);
+                transcription_config["ctrl"] = JsonConvert.DeserializeObject<Dictionary<string, object>>(smConfig.Ctrl);
             }
             transcription_config["language"] = smConfig.Model;
             if (additionalVocab != null)

--- a/SmRtAPI/SmRtAPI/Messages/StartRecognitionMessage.cs
+++ b/SmRtAPI/SmRtAPI/Messages/StartRecognitionMessage.cs
@@ -28,7 +28,7 @@ namespace Speechmatics.Realtime.Client.Messages
             {
                 transcription_config["max_delay_mode"] = smConfig.MaxDelayMode;
             }
-            if (smConfig.StreamingMode)
+            if (smConfig.StreamingMode)  // If statement because `streaming_mode` not in the API specs yet
             {
                 transcription_config["streaming_mode"] = smConfig.StreamingMode;
             }

--- a/SmRtAPI/SmRtAPI/Messages/StartRecognitionMessage.cs
+++ b/SmRtAPI/SmRtAPI/Messages/StartRecognitionMessage.cs
@@ -1,6 +1,7 @@
 ﻿using Speechmatics.Realtime.Client.Enumerations;
 using Speechmatics.Realtime.Client.Messages;
 using System.Collections.Generic;
+using System.Text.Json;
 
 namespace Speechmatics.Realtime.Client.Messages
 {
@@ -9,6 +10,10 @@ namespace Speechmatics.Realtime.Client.Messages
         public StartRecognitionMessage(SmRtApiConfigBase smConfig, AudioFormatSubMessage audioFormatSubMessage, AdditionalVocabSubMessage? additionalVocab)
         {
             audio_format = audioFormatSubMessage;
+            if (smConfig.Ctrl != null)
+            {
+                transcription_config["ctrl"] = JsonSerializer.Deserialize<Dictionary<string, object>>(smConfig.Ctrl);
+            }
             transcription_config["language"] = smConfig.Model;
             if (additionalVocab != null)
             {
@@ -23,13 +28,17 @@ namespace Speechmatics.Realtime.Client.Messages
             {
                 transcription_config["max_delay_mode"] = smConfig.MaxDelayMode;
             }
+            if (smConfig.StreamingMode != null)
+            {
+                transcription_config["streaming_mode"] = smConfig.StreamingMode;
+            }
             transcription_config["enable_partials"] = smConfig.EnablePartials;
             transcription_config["enable_entities"] = smConfig.EnableEntities;
             if (smConfig.OperatingPoint != null)
             {
                 transcription_config["operating_point"] = smConfig.OperatingPoint;
             }
-            if (DiarizationType.Speaker.Equals(smConfig.Diarization)) 
+            if (DiarizationType.Speaker.Equals(smConfig.Diarization))
             {
                 transcription_config["diarization"] = "speaker";
             }

--- a/SmRtAPI/SmRtAPI/Messages/StartRecognitionMessage.cs
+++ b/SmRtAPI/SmRtAPI/Messages/StartRecognitionMessage.cs
@@ -28,7 +28,7 @@ namespace Speechmatics.Realtime.Client.Messages
             {
                 transcription_config["max_delay_mode"] = smConfig.MaxDelayMode;
             }
-            if (smConfig.StreamingMode != null)
+            if (smConfig.StreamingMode)
             {
                 transcription_config["streaming_mode"] = smConfig.StreamingMode;
             }

--- a/SmRtAPI/SmRtAPI/SmRtApiConfigBase.cs
+++ b/SmRtAPI/SmRtAPI/SmRtApiConfigBase.cs
@@ -73,15 +73,20 @@ namespace Speechmatics.Realtime.Client
 
         /// <summary>
         /// API Authentication Token
-        /// only applicable for RT SaaS customers. 
+        /// only applicable for RT SaaS customers.
         /// </summary>
         public string AuthToken { get; set; }
 
         /// <summary>
-        /// API keys obtained through portal.speechmatics.com 
+        /// API keys obtained through portal.speechmatics.com
         /// need to set this to true
         /// </summary>
         public bool GenerateTempToken { get; set; } = false;
+
+        /// <summary>
+        /// Internal Speechmatics flag that allows to give special commands to the engine.
+        /// </summary>
+        public string Ctrl { get; set; }
 
         /// <summary>
         /// Maximum acceptable delay in seconds
@@ -90,7 +95,6 @@ namespace Speechmatics.Realtime.Client
         public double MaxDelay { get; set; } = 5;
 
         /// <summary>
-        /// 
         /// Determines whether the threshold specified in max_delay can be exceeded
         /// if a potential entity is detected.Flexible means if a potential entity
         /// is detected, then the max_delay can be overriden until the end of that
@@ -104,6 +108,11 @@ namespace Speechmatics.Realtime.Client
         /// where words are produced immediately, is enabled
         /// </summary>
         public bool EnablePartials { get; set; } = false;
+
+        /// <summary>
+        /// Indicates if we run the engine in streaming mode, or regular RT mode.
+        /// </summary>
+        public bool StreamingMode { get; set; } = false;
 
         /// <summary>
         /// Optional. Whether a user wishes for entities to be identified with additional spoken and written word format

--- a/SmRtAPI/SmRtAPI/SmRtApiConfigBase.cs
+++ b/SmRtAPI/SmRtAPI/SmRtApiConfigBase.cs
@@ -86,7 +86,7 @@ namespace Speechmatics.Realtime.Client
         /// <summary>
         /// Internal Speechmatics flag that allows to give special commands to the engine.
         /// </summary>
-        public string Ctrl { get; set; }
+        public string? Ctrl { get; set; }
 
         /// <summary>
         /// Maximum acceptable delay in seconds


### PR DESCRIPTION
Add flags for experimental streaming mode flags, along a ctrl flag that can be used to pass special internal commands to the container.   

Tested by passing:
```
                        Ctrl = "{\"skip_spec_validation\": true}",
                        StreamingMode = true,
```
In the C# DemoApp.