### PR TITLE
Server doesn't accept null translation_config, do not serialize if not set

### DIFF
--- a/SmRtAPI/SmRtAPI/Messages/StartRecognitionMessage.cs
+++ b/SmRtAPI/SmRtAPI/Messages/StartRecognitionMessage.cs
@@ -81,6 +81,7 @@ namespace Speechmatics.Realtime.Client.Messages
         public AudioFormatSubMessage audio_format { get; }
         public Dictionary<string, object> transcription_config { get; } = new Dictionary<string, object>();
 
+        [JsonProperty("translation_config", NullValueHandling = NullValueHandling.Ignore)]
         public Dictionary<string, object>? translation_config { get; }
     }
 }


### PR DESCRIPTION
Do not serialize translation_config if it's null, because the server doesn't accept null (None) here.